### PR TITLE
Fix: Pass Cloudflare runtime environment to email functions

### DIFF
--- a/src/lib/email/sender.ts
+++ b/src/lib/email/sender.ts
@@ -5,7 +5,7 @@
  */
 
 import { Resend } from 'resend';
-import { ENV, diagnoseEnvironment } from '../env';
+import { getCloudflareEnv, diagnoseEnvironment } from '../env';
 import type { ContactFormData, CurrentDataRequestFormData } from '../validationSchemas';
 import { 
   generateContactAdminEmailHtml,
@@ -32,8 +32,9 @@ export interface EmailResult {
   error?: string;
 }
 
-// Initialize Resend client
-const getResendClient = () => {
+// Initialize Resend client with Cloudflare runtime environment
+const getResendClient = (runtimeEnv?: any) => {
+  const ENV = getCloudflareEnv(runtimeEnv);
   const apiKey = ENV.RESEND_API_KEY;
   if (!apiKey) {
     throw new Error('RESEND_API_KEY is not configured');
@@ -41,9 +42,10 @@ const getResendClient = () => {
   return new Resend(apiKey);
 };
 
-export async function sendContactEmail(data: ContactFormData): Promise<EmailResult> {
+export async function sendContactEmail(data: ContactFormData, runtimeEnv?: any): Promise<EmailResult> {
   try {
-    const resend = getResendClient();
+    const ENV = getCloudflareEnv(runtimeEnv);
+    const resend = getResendClient(runtimeEnv);
     
     // Get language from data or default to 'ja'
     const language = (data as any).language || 'ja';
@@ -102,8 +104,10 @@ export async function sendContactEmail(data: ContactFormData): Promise<EmailResu
   }
 }
 
-export async function sendDataRequestEmail(data: CurrentDataRequestFormData): Promise<EmailResult> {
+export async function sendDataRequestEmail(data: CurrentDataRequestFormData, runtimeEnv?: any): Promise<EmailResult> {
   try {
+    const ENV = getCloudflareEnv(runtimeEnv);
+    
     console.log('🔍 [DATA REQUEST EMAIL DEBUG] Starting email send with config:', {
       fromEmail: ENV.REQUESTS_EMAIL,
       toEmail: ENV.TEST_EMAIL_RECIPIENT || ENV.ADMIN_EMAIL,
@@ -113,7 +117,7 @@ export async function sendDataRequestEmail(data: CurrentDataRequestFormData): Pr
       userName: data.name
     });
     
-    const resend = getResendClient();
+    const resend = getResendClient(runtimeEnv);
     
     // Get language from data or default to 'ja'
     const language = (data as any).language || 'ja';

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -6,7 +6,7 @@ import { logError, logInfo } from '@/lib/error-handling';
 // Enable server-side rendering for this endpoint
 export const prerender = false;
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
   try {
     // Validate Content-Type
     const contentType = request.headers.get('content-type');
@@ -76,8 +76,9 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // Validate email configuration
-    const emailConfig = validateEmailConfig();
+    // Validate email configuration with Cloudflare runtime
+    const env = locals.runtime?.env;
+    const emailConfig = validateEmailConfig(env);
     if (!emailConfig.isValid) {
       logError('Email configuration invalid for contact form', {
         operation: 'contact_form_email_config',
@@ -98,8 +99,8 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // Send email
-    const emailResult = await sendContactEmail(result.data);
+    // Send email with Cloudflare runtime environment
+    const emailResult = await sendContactEmail(result.data, env);
 
     if (!emailResult.success) {
       logError('Contact email sending failed', {

--- a/src/pages/api/request.ts
+++ b/src/pages/api/request.ts
@@ -142,8 +142,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
     console.log('Request data:', JSON.stringify(result.data, null, 2));
     
     console.log('📋 Step 7: Resend API Call');
-    // Send email
-    const emailResult = await sendDataRequestEmail(result.data);
+    // Send email with Cloudflare runtime environment
+    const emailResult = await sendDataRequestEmail(result.data, env);
     console.log('Email sending result:', emailResult);
 
     if (!emailResult.success) {


### PR DESCRIPTION
- Update sender.ts to accept runtimeEnv parameter
- Modify sendContactEmail and sendDataRequestEmail to use Cloudflare env
- Fix API endpoints to pass locals.runtime.env to email functions
- Enhance .gitignore with comprehensive security rules

🤖 Generated with [Claude Code](https://claude.ai/code)